### PR TITLE
update-parse-db-url

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,1 +1,0 @@
-DATABASE_URL=postgresql://postgres:5432/jwt_auth_service?user=bravos&password=4gi5uKqCtmYRRqRyoJTmu9U

--- a/src/main/java/com/bravos/steak/jwtauthentication/common/configuration/DatabaseConfiguration.java
+++ b/src/main/java/com/bravos/steak/jwtauthentication/common/configuration/DatabaseConfiguration.java
@@ -41,22 +41,23 @@ public class DatabaseConfiguration {
         String credentials = dbUrl.substring(0, atIndex);
         String hostPart = dbUrl.substring(atIndex + 1);
         int skip = credentials.indexOf("://") + 3;
-        int colonIndex = credentials.indexOf(':',skip);
+        int colonIndex = credentials.indexOf(':', skip);
         if (colonIndex == -1) {
             throw new IllegalArgumentException("Invalid credentials format.");
         }
         String username = credentials.substring(skip, colonIndex);
         String password = credentials.substring(colonIndex + 1);
 
-        String regex = "([^:]+):(\\d+)/(\\w+)";
+        String regex = "([^:]+)(?::(\\d+))?/(\\w+)";
         Matcher matcher = Pattern.compile(regex).matcher(hostPart);
         if (matcher.matches()) {
             String host = matcher.group(1);
-            String port = matcher.group(2);
+            String port = matcher.group(2) != null ? matcher.group(2) : "5432";
             String db = matcher.group(3);
             return String.format("jdbc:postgresql://%s:%s/%s?user=%s&password=%s", host, port, db, username, password);
         }
         throw new IllegalArgumentException("Invalid host part format.");
     }
+
 
 }


### PR DESCRIPTION
This pull request makes changes to improve database URL handling by updating the parsing logic and removing sensitive information from the example environment file. The key updates include modifying the regex to handle optional port numbers and setting a default port if none is provided.

### Database URL Parsing Improvements:

* [`src/main/java/com/bravos/steak/jwtauthentication/common/configuration/DatabaseConfiguration.java`](diffhunk://#diff-039dd04e02a773db55632b167a6aefdd426593503b464e1b2f4af4366fb7d5a8L51-R62): Updated the regex in the `parseCustomDbUrl` method to make the port number optional and added logic to default to port `5432` if the port is not specified. This improves flexibility in handling database URLs.