### PR TITLE
add-health-check

### DIFF
--- a/src/main/java/com/bravos/steak/jwtauthentication/common/configuration/SecurityConfiguration.java
+++ b/src/main/java/com/bravos/steak/jwtauthentication/common/configuration/SecurityConfiguration.java
@@ -48,7 +48,8 @@ public class SecurityConfiguration implements WebMvcConfigurer {
         http.authorizeHttpRequests(request -> {
 
             request.requestMatchers(
-                            "/auth/**")
+                            "/auth/**",
+                            "/api/healthz")
                     .permitAll();
 
             request.anyRequest().authenticated();

--- a/src/main/java/com/bravos/steak/jwtauthentication/common/controller/HealthCheckController.java
+++ b/src/main/java/com/bravos/steak/jwtauthentication/common/controller/HealthCheckController.java
@@ -1,0 +1,17 @@
+package com.bravos.steak.jwtauthentication.common.controller;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/healthz")
+public class HealthCheckController {
+
+    @GetMapping
+    public ResponseEntity<?> healthCheck() {
+        return ResponseEntity.ok().build();
+    }
+
+}


### PR DESCRIPTION
This pull request introduces a new health check endpoint (`/api/healthz`) to the application, ensuring it is publicly accessible without authentication. The changes include updates to the security configuration and the addition of a new controller for handling health check requests.

### Addition of health check functionality:

* **New health check controller**: Added the `HealthCheckController` class to handle requests to the `/api/healthz` endpoint. This controller responds with a 200 OK status to indicate the application's health. (`src/main/java/com/bravos/steak/jwtauthentication/common/controller/HealthCheckController.java`)

### Updates to security configuration:

* **Public access to health check endpoint**: Updated the `SecurityConfiguration` to allow unauthenticated access to the `/api/healthz` endpoint by adding it to the list of permitted request matchers. (`src/main/java/com/bravos/steak/jwtauthentication/common/configuration/SecurityConfiguration.java`)